### PR TITLE
Update to ESLint 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "esprima"
   ],
   "dependencies": {
-    "eslint": "~0.2.0",
+    "eslint": "~0.4.0",
     "eslint-stylish": "~0.1.0",
     "chalk": "~0.4.0"
   },


### PR DESCRIPTION
per http://eslint.org/blog/2014/02/eslint-0.4.0-released/

The complete list of breaking changes are as follows:

unnecessary-strict rule was renamed to no-extra-strict
regex-spaces rule was renamed to no-regex-spaces
no-new-array rule was renamed to no-array-constructor
Changed :after in node selectors to be :exit instead
