### PR TITLE
path.resolve(options.config)

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
 		}
 
 		if (options.config) {
-			args.push('--config', options.config);
+			args.push('--config', path.resolve(options.config));
 		}
 
 		if (options.rulesdir) {


### PR DESCRIPTION
either path is unused and can be removed, or options.config could use it for path resolution.
