### PR TITLE
simplify passing options to eslint

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -6,24 +6,14 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('eslint', 'Validate files with ESLint', function () {
 		var eslint = require('eslint').cli;
 		var options = this.options();
-		var args = ['', ''];
 
 		if (this.filesSrc.length === 0) {
 			return grunt.log.writeln(chalk.magenta('Couldn\'t find any files to validate.'));
 		}
 
-		if (options.config) {
-			args.push('--config', path.resolve(options.config));
-		}
+		options._ = this.filesSrc; // set positional arguments
+		options.config = path.resolve(options.config);
 
-		if (options.rulesdir) {
-			args.push('--rulesdir', options.rulesdir);
-		}
-
-		if (options.format) {
-			args.push('--format', options.format);
-		}
-
-		return eslint.execute(args.concat(this.filesSrc)) === 0;
+		return eslint.execute(options) === 0;
 	});
 };


### PR DESCRIPTION
eslint now uses gkz/optionator - one of the advantages of optionator
is that it can accept not only an array of arguments, but an object
(or string) as well
