### PR TITLE
Fix readme for grunt configuration.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,9 @@ See the grunt [docs](https://github.com/gruntjs/grunt/wiki) on how to [configure
 ```js
 grunt.initConfig({
 	eslint: {					// task
-		target: ['file.js']		// array of files
+		files: {
+			src: ['file.js']		// array of files
+		}
 	}
 });
 
@@ -51,7 +53,9 @@ grunt.initConfig({
 			config: 'conf/eslint.json',		// custom config
 			rulesdir: 'conf/rules'			// custom rules
 		},
-		target: ['file.js']					// array of files
+		files: {
+			src: ['file.js']					// array of files
+		}
 	}
 });
 


### PR DESCRIPTION
The readme states that `target` is used to specify files. The eslint grunt task however uses `this.filesSrc`.
