### PR TITLE
prevent error if option config is not exist with edge version on github.

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
 		}
 
 		options._ = this.filesSrc; // set positional arguments
-		options.config = !!options.config ? path.resolve(options.config) : '';
+		options.config = options.config ? path.resolve(options.config) : '';
 
 		return eslint.execute(options) === 0;
 	});


### PR DESCRIPTION
Hi. Thanks for nice plugin.

If there is no option config with edge version , following error occured.

```
Warning: Arguments to path.resolve must be strings Use --force to continue.
```

config is required?
