### PR TITLE
fix issue with writing to outfile

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -40,7 +40,12 @@ module.exports = function (grunt) {
 			return;
 		}
 
-		console.log(formatter(results));
+		var formattedResults = formatter(results);
+		if (opts['output-file']) {
+			grunt.file.write(opts['output-file'], formattedResults);
+		} else {
+			console.log(formattedResults);
+		}
 		return calculateExitCode(results) === 0;
 	});
 };


### PR DESCRIPTION
after changing to CLIEngine in version 5.0.0 grunt-eslint stopped respecting the output-file option and output was written to console instead of file.