### PR TITLE
Add an option to fail the task when warnings are found.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,8 @@ module.exports = function (grunt) {
 			options: {
 				configFile: 'conf/eslint.json',
 				rulePaths: ['conf/rules'],
-				quiet: true
+				quiet: true,
+				failOnWarnings: false
 			},
 			validate: ['test/fixture/{1,2}.js']
 		},

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,14 @@ Default: `false`
 Report errors only.
 
 
+### failOnWarnings
+
+Type: `boolean`  
+Default: `false`
+
+Fail the task when warnings are found.
+
+
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -6,7 +6,8 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('eslint', 'Validate files with ESLint', function () {
 		var opts = this.options({
 			outputFile: false,
-			quiet: false
+			quiet: false,
+			failOnWarnings: false
 		});
 
 		// legacy
@@ -54,6 +55,6 @@ module.exports = function (grunt) {
 			console.log(output);
 		}
 
-		return report.errorCount === 0;
+		return report.errorCount === 0 && (!opts.failOnWarnings || report.warningCount === 0);
 	});
 };


### PR DESCRIPTION
We want to be able to use the linting in Jenkins tasks to trigger reports when the build is broken, and we'd like this to fire when warnings are found, as well as errors.