### PR TITLE
Adds a maxWarnings option. Closes #90

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,14 @@ Default: `false`
 Report errors only.
 
 
+### maxWarnings
+
+Type: `number`  
+Default: `-1`
+
+Number of warnings to trigger nonzero exit code (-1 means no limit)
+
+
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -6,7 +6,8 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('eslint', 'Validate files with ESLint', function () {
 		var opts = this.options({
 			outputFile: false,
-			quiet: false
+			quiet: false,
+			maxWarnings: -1
 		});
 
 		// legacy
@@ -58,6 +59,12 @@ module.exports = function (grunt) {
 			console.log(output);
 		}
 
-		return report.errorCount === 0;
+		var tooManyWarnings = opts.maxWarnings >= 0 && report.warningCount > opts.maxWarnings;
+
+		if (!report.errorCount && tooManyWarnings) {
+			console.error("ESLint found too many warnings (maximum: %s).", opts.maxWarnings);
+		}
+
+		return (report.errorCount || tooManyWarnings) ? 1 : 0;
 	});
 };


### PR DESCRIPTION
While it would be nice if ESLint had --max-warnings embedded in CLIEngine so that the grunt tasks gets the option for free, that may end up being a risky change that involves a lot of discussion. For now it's easier to just add the option here. 