### PR TITLE
Fixed: reversed logic introduced with tooManyWarnings feature. (see #90)

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -61,10 +61,10 @@ module.exports = function (grunt) {
 
 		var tooManyWarnings = opts.maxWarnings >= 0 && report.warningCount > opts.maxWarnings;
 
-		if (report.errorCount === 0 && tooManyWarnings > 0) {
-			console.error('ESLint found too many warnings (maximum: %s)', opts.maxWarnings);
+		if (report.errorCount === 0 && tooManyWarnings) {
+			grunt.warn('ESLint found too many warnings (maximum:' + opts.maxWarnings + ')');
 		}
 
-		return (report.errorCount > 0 || tooManyWarnings > 0) ? 1 : 0;
+		return report.errorCount === 0;
 	});
 };


### PR DESCRIPTION
Uses grunt.warn() to indicate when there are too many warnings.

Therefore the final return statement can be reverted back to
"report.errorCount === 0".