### PR TITLE
Output message on success

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -46,6 +46,7 @@ module.exports = function (grunt) {
 		}
 
 		var results = report.results;
+		var numFiles = results.length;
 
 		if (opts.quiet) {
 			results = eslint.CLIEngine.getErrorResults(results);
@@ -55,16 +56,24 @@ module.exports = function (grunt) {
 
 		if (opts.outputFile) {
 			grunt.file.write(opts.outputFile, output);
-		} else {
+		} else if (output) {
 			console.log(output);
+		}
+
+		if (report.errorCount !== 0) {
+			return false;
 		}
 
 		var tooManyWarnings = opts.maxWarnings >= 0 && report.warningCount > opts.maxWarnings;
 
-		if (report.errorCount === 0 && tooManyWarnings) {
+		if (tooManyWarnings) {
 			grunt.warn('ESLint found too many warnings (maximum:' + opts.maxWarnings + ')');
 		}
 
-		return report.errorCount === 0;
+		if (!output) { // there were no errors and no output warnings
+			grunt.log.ok(numFiles + ' ' + grunt.util.pluralize(numFiles, 'file/files') + ' lint free.');
+		}
+
+		return true;
 	});
 };


### PR DESCRIPTION
Output a message when the `eslint` task completes without outputting any errors or warnings, just like `grunt-jsonlint`, `grunt-contrib-jshint`, and `grunt-jscs`.

#### Before:
![grunt-eslint-output-before](https://cloud.githubusercontent.com/assets/5128013/12698736/8427911a-c772-11e5-9ab3-b37bd39785c8.PNG)

#### After:
![grunt-eslint-output](https://cloud.githubusercontent.com/assets/5128013/12698728/48681532-c772-11e5-96b3-0d90a2a63d51.PNG)