### PR TITLE
Updated eslint version to latest 1.x and fixed annoying line feed issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
-    "eslint": "^1.5.1"
+    "eslint": "^1.10.3"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -56,7 +56,9 @@ module.exports = function (grunt) {
 		if (opts.outputFile) {
 			grunt.file.write(opts.outputFile, output);
 		} else {
-			console.log(output);
+			if (output.length !== 0) {
+				console.log(output)
+			}
 		}
 
 		var tooManyWarnings = opts.maxWarnings >= 0 && report.warningCount > opts.maxWarnings;


### PR DESCRIPTION
I updated eslint to the latest version and also fixed an annoying line feed issue occurring when the linting passed just looks prettier since all the other grunt tasks doesn't add any empty lines.