### PR TITLE
Use opts.quiet when determining return value

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -55,7 +55,14 @@ module.exports = grunt => {
 		if (report.errorCount === 0 && tooManyWarnings) {
 			grunt.warn(`ESLint found too many warnings (maximum: ${opts.maxWarnings})`);
 		}
+		
+		let totalViolationCount;
+		if (opts.quiet) {
+			totalViolationCount = report.errorCount;
+		} else {
+			totalViolationCount = report.errorCount + report.warningCount;
+		}
 
-		return report.errorCount === 0;
+		return totalViolationCount === 0;
 	});
 };


### PR DESCRIPTION
Currently, this task returns `true` when there are lint warnings, and `quiet` is set to false. This makes it difficult to fail a build in a CI environment for warnings. This PR makes it possible for Grunt to return a non-0 exit code when lint warnings are present.

If `opts.quiet` is set to `false` (default), then this task will return `false` if there are any errors *or* warnings. If `opts.quiet` is `true`, then this task will only return `false` if there are errors.