### PR TITLE
Pin eslint versions due to every update eslint does breaks tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
-    "eslint": "^3.0.0"
+    "eslint": "3.12.2"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
This pull pins eslint to a specific version and should be bumped which would then require repo version bump.

This will improve stability.

wmf (Wikimedia) keeps hitting this problem with ci.