### PR TITLE
Allow eslint v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
-    "eslint": "^3.0.0"
+    "eslint": "^3.0.0|^4.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
AFAIK there are no API changes for users of eslint.