### PR TITLE
Add Node.js 8 to Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '8'
   - '6'
   - '4'


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v8.0.0/
https://nodejs.org/en/blog/release/v8.1.0/