### PR TITLE
Remove grunt from peerDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,6 @@
     "grunt-cli": "^1.2.0",
     "grunt-shell": "^1.1.1"
   },
-  "peerDependencies": {
-    "grunt": ">=0.4.0"
-  },
   "xo": {
     "esnext": true
   }


### PR DESCRIPTION
Ref: https://github.com/gruntjs/grunt/issues/1116

I think `grunt` as a peer dep should be removed. We have already removed `grunt` from `peerDependencies` in the `contrib-*` plugins as older versions of npm fail with `EPEERINVALID` on them.

Given how broken peer deps can be and that they are deprecated, we are recommending removing `grunt` as a peer dep.

Thanks!