### PR TITLE
Use to latest Chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "esprima"
   ],
   "dependencies": {
-    "chalk": "^1.0.0",
+    "chalk": "^2.1.0",
     "eslint": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Latest eslint (v20) uses chalk@^2.1.0 [1]. This matches PR adjusts package.json to match that version.

Locally, when running the eslint task, I was seeing "chalk#stripColor is not a function".

1. https://github.com/eslint/eslint/blob/master/package.json#L40
