### PR TITLE
Add `failOnError` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Number of warnings to trigger non-zero exit code.
 Type: `boolean`<br>
 Default: `true`
 
-If the build should fail if any error is found.
+Fail the build if ESLint found any errors.
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,13 @@ Default: `-1` *(means no limit)*
 
 Number of warnings to trigger non-zero exit code.
 
+### failOnError
+
+Type: `boolean`<br>
+Default: `true`
+
+If the build should fail if any error is found.
+
 
 ## License
 

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -57,6 +57,6 @@ module.exports = grunt => {
 			grunt.warn(`ESLint found too many warnings (maximum: ${opts.maxWarnings})`);
 		}
 
-		return failOnError ? report.errorCount === 0 : 0;
+		return opts.failOnError ? report.errorCount === 0 : 0;
 	});
 };

--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -7,7 +7,8 @@ module.exports = grunt => {
 		const opts = this.options({
 			outputFile: false,
 			quiet: false,
-			maxWarnings: -1
+			maxWarnings: -1,
+			failOnError: true,
 		});
 
 		if (this.filesSrc.length === 0) {
@@ -56,6 +57,6 @@ module.exports = grunt => {
 			grunt.warn(`ESLint found too many warnings (maximum: ${opts.maxWarnings})`);
 		}
 
-		return report.errorCount === 0;
+		return failOnError ? report.errorCount === 0 : 0;
 	});
 };


### PR DESCRIPTION
This is useful for CI to perform other build steps. It has been requested in issue #137 

This doesn't break current configuration as the default value will behave the same as is currently does.