### PR TITLE
Bump the eslint version to 5.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	],
 	"dependencies": {
 		"chalk": "^2.1.0",
-		"eslint": "^5.0.0"
+		"eslint": "^5.16.0"
 	},
 	"devDependencies": {
 		"grunt": "^1.0.1",


### PR DESCRIPTION
Among other things, this updates the
js-yaml version used to resolve WS-2019-0063.

on-behalf-of: @wmde <leszek.manicki@wikimedia.de>