### PR TITLE
Support async formatters

### DIFF
--- a/tasks/eslint.js
+++ b/tasks/eslint.js
@@ -49,7 +49,7 @@ module.exports = grunt => {
 					results = ESLint.getErrorResults(results);
 				}
 
-				const output = formatter.format(results);
+				const output = await formatter.format(results);
 
 				if (outputFile) {
 					grunt.file.write(outputFile, output);


### PR DESCRIPTION
Some formatters return promises, such as eslint-formatter-todo, which grunt-eslint doesn't currently handle.  
See https://github.com/lint-todo/eslint-formatter-todo/blob/main/src/formatter.ts#L101

Instead of formatting grunt-eslint gives this: 
![image](https://user-images.githubusercontent.com/3609063/236891926-350bf96e-aa19-48a1-863f-2ecd1f35e079.png)

I think simply making the format call async will properly handle this.  I've tried it with both sync and async formatters and seems to work as expected.