### PR TITLE
Upgrade to ESLint 9, flatconfig and Node.js 18 (#173)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
-          - 12
+          - 20
+          - 18
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
           - 20
           - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/conf/eslint.js
+++ b/conf/eslint.js
@@ -1,0 +1,8 @@
+module.exports = [
+	{
+		rules: {
+			'no-alert': 1,
+			'camelcase': 2
+		}
+	}
+];

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -1,6 +1,0 @@
-{
-	"rules": {
-		"no-alert": 1,
-		"camelcase": 2
-	}
-}

--- a/conf/rules/no-alert.js
+++ b/conf/rules/no-alert.js
@@ -1,10 +1,12 @@
 'use strict';
-module.exports = function (context) {
-	return {
-		CallExpression(node) {
-			if (node.callee.name === 'alert') {
-				context.report(node, 'testing custom rules.');
+module.exports = {
+	create(context) {
+		return {
+			CallExpression(node) {
+				if (node.callee.name === 'alert') {
+					context.report(node, 'testing custom rules.');
+				}
 			}
-		}
-	};
+		};
+	}
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,10 +1,13 @@
 'use strict';
+
+const noAlertRule = require('./conf/rules/no-alert');
+
 module.exports = grunt => {
 	grunt.initConfig({
 		eslint: {
 			options: {
-				overrideConfigFile: 'conf/eslint.json',
-				rulePaths: ['conf/rules'],
+				overrideConfigFile: 'conf/eslint.js',
+				plugins: { noAlertRule },
 				quiet: true
 			},
 			validate: ['test/fixture/{1,2}.js']

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -7,7 +7,9 @@ module.exports = grunt => {
 		eslint: {
 			options: {
 				overrideConfigFile: 'conf/eslint.js',
-				plugins: { noAlertRule },
+				plugins: {
+					noAlertRule
+				},
 				quiet: true
 			},
 			validate: ['test/fixture/{1,2}.js']

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=12"
+		"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 	},
 	"scripts": {
 		"test": "grunt"
@@ -28,10 +28,10 @@
 	],
 	"dependencies": {
 		"chalk": "^4.1.2",
-		"eslint": "^8.44.0"
+		"eslint": "^9.0.0"
 	},
 	"devDependencies": {
-		"grunt": "^1.0.1",
+		"grunt": "^1.6.1",
 		"grunt-cli": "^1.4.3",
 		"grunt-shell": "^4.0.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,13 @@ grunt.registerTask('default', ['eslint']);
 ### Custom config and rules
 
 ```js
+const noAlertRule = require('./conf/rules/no-alert');
+
 grunt.initConfig({
 	eslint: {
 		options: {
-			overrideConfigFile: 'conf/eslint.json',
-			rulePaths: ['conf/rules']
+			overrideConfigFile: 'conf/eslint.js',
+			plugins: { noAlertRule }
 		},
 		target: ['file.js']
 	}
@@ -46,7 +48,7 @@ grunt.initConfig({
 grunt.initConfig({
 	eslint: {
 		options: {
-			format: require('eslint-tap')
+			format: './node_modules/eslint-tap/index.js'
 		},
 		target: ['file.js']
 	}

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,9 @@ grunt.initConfig({
 	eslint: {
 		options: {
 			overrideConfigFile: 'conf/eslint.js',
-			plugins: { noAlertRule }
+			plugins: {
+				noAlertRule
+			}
 		},
 		target: ['file.js']
 	}


### PR DESCRIPTION
Upgrade the eslint dependency. Change the documentation and tests to use the new configuration format. Also, upgrade Node.js in the build pipeline.

> When ESLint v10.0.0 is released (end of 2024 or early 2025 in all likelihood),
  the eslintrc configuration system will be completely removed.

https://eslint.org/blog/2023/10/flat-config-rollout-plans/#eslintrc-removed-in-eslint-v10.0.0

* Describe and test the usage only with flatconfig. It'll be the only config format soon. Who needs to retain `.eslintrc` can stay with eslint 8.
* ESLint 9 supports only Node.js `^18.18.0 || ^20.9.0 || >=21.1.0`.
* The formatter `eslint-tap` works, but because it doesn't follow the NPM package naming convention `eslint-formatter-*`, it has to be specified using a path to the script with the main exports.

Fixes #173